### PR TITLE
fixed refresh issue

### DIFF
--- a/pages/hacktoberfest/leaderboard.tsx
+++ b/pages/hacktoberfest/leaderboard.tsx
@@ -28,8 +28,10 @@ const Leaderboard: React.FC = () => {
     }, [])
 
     React.useEffect(() => {
+        window.onbeforeunload = () => {
+            window.scrollTo({top:0, behavior:'smooth'});
+          }
         handleLeaderboardFetch();
-
     }, [])
 
     return (


### PR DESCRIPTION
## Description
<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Now on refreshing the leaderboard page, it always shows the top of the page.

---
## Issue Ticket Number
Fixes #238 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes needed to the documentation