### PR TITLE
Remove unnecessary Href from image

### DIFF
--- a/pages/components/Hacktoberfest/Swags.tsx
+++ b/pages/components/Hacktoberfest/Swags.tsx
@@ -19,9 +19,7 @@ const Swags = () => {
                         </a>
                     </Link>
                 </div>
-                <Link href='#' passHref>
-                    <img src='/contribute.png' className='mx-auto ' />
-                </Link>
+                <img src='/contribute.png' className='mx-auto ' />
             </div>
         </div>
     )


### PR DESCRIPTION
## Description
Removed unnecessary link from image on the Hacktoberfest page

---
## Issue Ticket Number
Fixes #248 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation