### PR TITLE
Fixed the social icons positioning issue in the members card

### DIFF
--- a/pages/components/AboutUS/ProfileCard.tsx
+++ b/pages/components/AboutUS/ProfileCard.tsx
@@ -22,7 +22,7 @@ const ProfileCard: React.FC<Props> = ({key, img, username, tag, about, github, l
             <img className="h-20 w-20 my-3 rounded-full" src={img} alt="" />
             <h1 className="font-raleway font-semibold mt-2 text-center">{username}</h1>
             <h2 className="font-raleway text-[#7E7E7E] text-xs mt-1 mb-2">{tag}</h2>
-            <p className=" font-nunito font-semibold text-sm mt-5 text-center">{about}</p>
+            <p className="h-20 font-nunito font-semibold text-sm mt-5 mb-4 text-center">{about}</p>
             <div className="mt-8 w-4/5 flex justify-between">
                 <a href={github} target="_blank" rel="noreferrer"><GitHubIcon/></a>
                 <a href={linkedin} target="_blank" rel="noreferrer"><LinkedInIcon/></a>


### PR DESCRIPTION
## Description
I have fixed the social icons positioning issue in the members card in the about us section. The social icons are now aligned at the same level for every card and don't break the UI. Also, it's responsive.

---
## Issue Ticket Number
Fixes #271 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation

## Screenshots 👇

![Screenshot 2022-10-16 225607](https://user-images.githubusercontent.com/85431456/196051029-34d52906-e0c9-46f8-bece-17bcaf03f1d0.png)
