### PR TITLE
Added About Us tab in the Navbar as well as Sidebar

### DIFF
--- a/pages/components/AboutUS/ProfileCard.tsx
+++ b/pages/components/AboutUS/ProfileCard.tsx
@@ -22,7 +22,7 @@ const ProfileCard: React.FC<Props> = ({key, img, username, tag, about, github, l
             <img className="h-20 w-20 my-3 rounded-full" src={img} alt="" />
             <h1 className="font-raleway font-semibold mt-2 text-center">{username}</h1>
             <h2 className="font-raleway text-[#7E7E7E] text-xs mt-1 mb-2">{tag}</h2>
-            <p className=" font-nunito font-semibold text-sm mt-5 text-center">{about}</p>
+            <p className="h-20 font-nunito font-semibold text-sm mt-5 mb-4 text-center">{about}</p>
             <div className="mt-8 w-4/5 flex justify-between">
                 <a href={github} target="_blank" rel="noreferrer"><GitHubIcon/></a>
                 <a href={linkedin} target="_blank" rel="noreferrer"><LinkedInIcon/></a>

--- a/pages/components/shared/Navbar/Navbar.tsx
+++ b/pages/components/shared/Navbar/Navbar.tsx
@@ -55,6 +55,11 @@ const Navbar: NextComponentType = () => {
             Events
           </button>
         </Link>
+        <Link href="/about-us" passHref>
+          <button className="hover:font-semibold hover:underline cursor-pointer xl:mx-8 mx-3 text-xl transition-all">
+            About Us
+          </button>
+        </Link>
       </div>
       {session.status === "authenticated" && (
         <div className="hidden md:block">

--- a/pages/components/shared/Navbar/NavbarDrawer.tsx
+++ b/pages/components/shared/Navbar/NavbarDrawer.tsx
@@ -121,6 +121,15 @@ const NavbarDrawer: React.FC<Props> = ({ img, name, email, uid }) => {
                 Events
               </button>
             </Link>
+            <div className="bg-gray-300 h-[1px] w-10/12 mx-auto mt-3"></div>
+            <Link href="/about-us" passHref>
+              <button
+                onClick={handleClose}
+                className="font-semibold text-xl mt-5"
+              >
+                About Us
+              </button>
+            </Link>
             {session.status === "unauthenticated" && (
               <>
                 <div className="bg-gray-300 h-[1px] w-10/12 mx-auto mt-3"></div>


### PR DESCRIPTION
## Description
I have added the About Us tab/link in the Navbar as well as Sidebar. It is responsive.

---
## Issue Ticket Number
Fixes #268 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation

## Screenshots 👇

![Screenshot (519)](https://user-images.githubusercontent.com/85431456/196052231-a8f03ae9-520a-4588-a98e-94621bae7b07.png)

![Screenshot 2022-10-17 000542](https://user-images.githubusercontent.com/85431456/196052257-e6a8c378-cbcc-4f03-9782-5fc3465b8f21.png)

