### PR TITLE
Made some minor UI fixes in the Leaderboard page

### DIFF
--- a/pages/hacktoberfest/leaderboard.tsx
+++ b/pages/hacktoberfest/leaderboard.tsx
@@ -83,7 +83,7 @@ const Leaderboard: React.FC = (leaderboardData) => {
                                     : data.avatarUrl;
                             return (
                                 data.userName != 'Rajdip019' && <tr
-                                    className={`${i % 2 === 0 && "bg-[#DBE0EB]"} rounded-md`}
+                                    className={`${i % 2 === 0 && "bg-[#889abf]"} rounded-md`}
                                     key={i}
                                 >
                                     <td
@@ -104,7 +104,7 @@ const Leaderboard: React.FC = (leaderboardData) => {
                                         </span>
                                     </td>
                                     <td
-                                        className={`my-2 pl-2 xl:rounded-tl-md rounded-tl-sm xl:rounded-bl-md rounded-bl-sm font-semibold text-center`}
+                                        className={`my-2 pl-2 font-semibold text-center`}
                                     >
                                         {data.PRCount}
                                     </td>


### PR DESCRIPTION
## Description
I have made some minor UI fixes on the leaderboard page. The 'PR Merged' column had some rounded borders glitch, so removed that. Also, in the dark mode, the user entries which were in odds place had white background due to which the data was not clearly visible. So, changed the color which will suit both, light as well as dark modes.

Before 👇

![Screenshot 2022-10-20 222507](https://user-images.githubusercontent.com/85431456/197024335-c087c180-2310-4286-9cf2-742b323e18f3.png)

<br/><br/>
After 👇

![Screenshot 2022-10-20 222532](https://user-images.githubusercontent.com/85431456/197024382-220f1518-b195-4adf-873d-fe7ecf5aee62.png)

---
## Type of change
<!-- Please select all options that are applicable. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation