### PR TITLE
fix: add card height to prevent unequal height

### DIFF
--- a/pages/components/Hacktoberfest/ProjectCard.tsx
+++ b/pages/components/Hacktoberfest/ProjectCard.tsx
@@ -13,7 +13,7 @@ interface ProjectProps {
 
 const ProjectCard: React.FC<ProjectProps> = ({ name, description, imgSources, repoUrl }) => {
   return (
-    <div className="md:w-[475px] bg-gradient-to-r from-black via-blue-1000 to-blue-800 rounded-2xl p-[57px]">
+    <div className="md:w-[550px] h-[470px] bg-gradient-to-r from-black via-blue-1000 to-blue-800 rounded-2xl p-[57px]">
       <h1 className="text-white text-[24px] lg:text-3xl">{name}</h1>
       <div className="space-y-12">
         <p className="text-white text-md md:text-lg md:font-light	">{description}</p>

--- a/pages/components/Hacktoberfest/Projects.tsx
+++ b/pages/components/Hacktoberfest/Projects.tsx
@@ -8,7 +8,7 @@ const Projects = () => {
             <h1 className='mb-20 text-center text-[24px] lg:text-3xl xl:text-4xl'>Projects 🚀</h1>
             {/* <div className='md:grid gap-10 xl:grid-cols-2 m-10 md:mx-40 flex flex-col justify-center text-center lg:text-left rounded-3xl py-[28px] px-[20px] sm:px-[91px]'> */}
             {/* <div className='md:grid md:grid-col-2 md:gap-2 md:px-0 md:py-0 md:space-y-0 flex flex-col justify-center items-center space-y-12 px-12 py-2 '> */}
-            <div className='lg:grid lg:grid-cols-2 lg:gap-10 lg:justify-items-center lg:space-y-0 lg:px-0 lg:py-0 flex flex-col justify-center items-center space-y-12 px-12 py-2 '>
+            <div className='lg:grid lg:grid-cols-2 lg:gap-10 lg:justify-items-center lg:space-y-0  lg:px-0 lg:py-0 flex flex-col justify-center items-center space-y-12 px-12 py-2 '>
                 {ProjectsHacktoberFest?.map((item, i) => {
                     return <ProjectCard key={i} name={item?.Name} description={item?.Description} imgSources={item?.techstack_Icon} repoUrl={item?.repoUrl} />
                 })}


### PR DESCRIPTION
## Description
<!-- Include a summary of the change made and also list the dependencies that are required if any -->
card height is unequal. added tailwind height property to prevent uneven height. NOTE height must be set to prevent this, without height property internal elements wrap and height are automatically set to fit the content.
---
## Issue Ticket Number
Fixes #(issue_number)

---
## Type of change
<!-- Please select all options that are applicable. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation