### PR TITLE
fix: Fix case sensitivity in Leaderboard Search

### DIFF
--- a/pages/hacktoberfest/leaderboard.tsx
+++ b/pages/hacktoberfest/leaderboard.tsx
@@ -36,7 +36,7 @@ const Leaderboard: React.FC = (leaderboardData) => {
         const SearchBar = document.getElementById('searchBar') as HTMLInputElement;
         
         clearSearchFlag ? (setSearch(""), searchRes = allData, SearchBar.value = "")
-        : searchRes = allData.filter((item: Ileaderboard) =>item.userName.includes(search));
+        : searchRes = allData.filter((item: Ileaderboard) =>item.userName.toLowerCase().includes(search.toLowerCase()));
         setSearchResult(searchRes);
     }
     


### PR DESCRIPTION
## Description
<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Fixed case sensitivity in Leaderboard Search

![#cl2](https://user-images.githubusercontent.com/74665996/198010127-5e8d07b7-6b5f-4e46-bf9d-d3379dd7f345.png)


---
## Issue Ticket Number
Fixes #399 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation