### PR TITLE
Added hover effect to socials icons on profile page

### DIFF
--- a/pages/components/Profile/ProfileSummary.tsx
+++ b/pages/components/Profile/ProfileSummary.tsx
@@ -48,7 +48,7 @@ const ProfileSummary: React.FC<Props> = ({
      <a
       href={githubLink}
       target='_blank'
-      className=' opacity-80'
+      className=' opacity-80 hover:opacity-90 transition-transform hover:scale-90'
       rel='noreferrer'
      >
       <GitHubIcon fontSize='large' />
@@ -58,7 +58,7 @@ const ProfileSummary: React.FC<Props> = ({
      <a
       href={linkedInLink}
       target='_blank'
-      className=' opacity-80'
+      className=' opacity-80 hover:opacity-90 transition-transform hover:scale-90'
       rel='noreferrer'
      >
       <LinkedInIcon fontSize='large' />
@@ -68,7 +68,7 @@ const ProfileSummary: React.FC<Props> = ({
      <a
       href={twitterlink}
       target='_blank'
-      className=' opacity-80'
+      className=' opacity-80 hover:opacity-90 transition-transform hover:scale-90'
       rel='noreferrer'
      >
       <TwitterIcon fontSize='large' />


### PR DESCRIPTION

## Description
Added hover effect to social icons in profile by increasing the opacity from 0.8 to 0.9 and reducing the size by 10% on hover

---
## Issue Ticket Number
Fixes #396

---
## Type of change
<!-- Please select all options that are applicable. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation

---
# Before Hovering
<img width="222" alt="image" src="https://user-images.githubusercontent.com/73149618/198051524-9d632066-b2b6-47d0-9ba2-5e803ef558ba.png">

# After Hovering
<img width="205" alt="image" src="https://user-images.githubusercontent.com/73149618/198051858-a51fbabe-53c8-484e-ad81-195ca6b89bc4.png">
