### PR TITLE
redirect to github link on click in leaderboard

### DIFF
--- a/pages/hacktoberfest/leaderboard.tsx
+++ b/pages/hacktoberfest/leaderboard.tsx
@@ -140,7 +140,7 @@ const Leaderboard: React.FC = (leaderboardData) => {
                                         </div>
                                     </td>
                                 </tr>
-                            );
+                            ))
                         })}
                     </tbody>
                 </table>

--- a/pages/hacktoberfest/leaderboard.tsx
+++ b/pages/hacktoberfest/leaderboard.tsx
@@ -121,12 +121,15 @@ const Leaderboard: React.FC = (leaderboardData) => {
                       {data.position}.
                     </td>
                     <td className={`my-2 flex justify-start items-center xl:space-x-4 space-x-2 w-full`}>
-                      <img
-                        src={avatarURL}
-                        className="w-16 rounded-full border-dashed border-2 border-blue-400 text-sm "
-                        alt=""
-                      />
-                      <span className="max-w-[113px] truncate sm:max-w-fit">{data.userName}</span>
+                        <img
+                            src={avatarURL}
+                            className="w-16 rounded-full border-dashed border-2 border-blue-400 text-sm "
+                            alt=""
+                            onClick={() => window.location.href=`https://github.com/${data.userName}`}
+                        />
+                        <span onClick={() => window.location.href=`https://github.com/${data.userName}`} className="max-w-[113px] truncate sm:max-w-fit">
+                            {data.userName}
+                        </span>
                     </td>
                     <td
                       className={`my-2 pl-2 xl:rounded-tl-md rounded-tl-sm xl:rounded-bl-md rounded-bl-sm font-semibold text-center`}


### PR DESCRIPTION
## Description
<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Now it redirects to the github profile when clicked on the username or the image in leaderboard.

---
## Issue Ticket Number
Fixes #387 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation