### PR TITLE
Fixed Techstack color in dark mode

### DIFF
--- a/pages/components/shared/StyledChip.tsx
+++ b/pages/components/shared/StyledChip.tsx
@@ -1,20 +1,20 @@
-import React from 'react'
+import React from "react";
 
 interface Props {
-    text: string
-    size : 'xl' | 'sm' | 'xs' | 'lg' | 'md',
-    rounded: 'xl' | 'sm' | 'xs' | 'lg' | 'md' | '2xl' | '3xl'
+  text: string;
+  size: "xl" | "sm" | "xs" | "lg" | "md";
+  rounded: "xl" | "sm" | "xs" | "lg" | "md" | "2xl" | "3xl";
 }
 
 const StyledChip: React.FC<Props> = ({ text, size, rounded }) => {
-    return (
-        <div
-            title={text}
-            className={`bg-[#A1BFF9] px-3 whitespace-nowrap overflow-hidden text-ellipsis py-2 font-bold text-${size} rounded-${rounded} my-0`}
-        >
-            {text}
-        </div>
-    );
-}
+  return (
+    <div
+      title={text}
+      className={`bg-[#A1BFF9] dark:bg-[#2E4053] px-3 whitespace-nowrap overflow-hidden text-ellipsis py-2 font-bold text-${size} rounded-${rounded} my-0`}
+    >
+      {text}
+    </div>
+  );
+};
 
-export default StyledChip
+export default StyledChip;


### PR DESCRIPTION
## Description
Fixed Techstack color in dark mode
![image](https://user-images.githubusercontent.com/104709529/198121198-7dd7a13b-6b75-40d5-beea-70854ec7282f.png)


---
## Issue Ticket Number
Fixes #397 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation