### PR TITLE
added hover effect and links open on new tab

### DIFF
--- a/pages/hacktoberfest/leaderboard.tsx
+++ b/pages/hacktoberfest/leaderboard.tsx
@@ -14,32 +14,41 @@ interface Ileaderboard {
 }
 
 const Leaderboard: React.FC = (leaderboardData) => {
-    
     const leaderBoardDataArray: any = Object.values(leaderboardData)[0];
 
-    const allData = leaderBoardDataArray && leaderBoardDataArray.map((i: any,ind: number) => ({...i, "position": ind+1})) as Ileaderboard[];
-    
+    const allData =
+        leaderBoardDataArray &&
+        (leaderBoardDataArray.map((i: any, ind: number) => ({
+            ...i,
+            position: ind + 1,
+        })) as Ileaderboard[]);
+
     const [search, setSearch] = useState("");
     const [showButton, setShowButton] = useState(false);
     const [searchResult, setSearchResult] = useState(allData);
 
     const searchStyles = {
-      width: '100%',
-      margin: '30px 0',
-      display: 'flex',
-      height: 42,
-      overflow:'hidden'
-    }
-  
-    function searchCards(clearSearchFlag : boolean){
+        width: "100%",
+        margin: "30px 0",
+        display: "flex",
+        height: 42,
+        overflow: "hidden",
+    };
+
+    function searchCards(clearSearchFlag: boolean) {
         let searchRes;
-        const SearchBar = document.getElementById('searchBar') as HTMLInputElement;
-        
-        clearSearchFlag ? (setSearch(""), searchRes = allData, SearchBar.value = "")
-        : searchRes = allData.filter((item: Ileaderboard) =>item.userName.toLowerCase().includes(search.toLowerCase()));
+        const SearchBar = document.getElementById(
+            "searchBar"
+        ) as HTMLInputElement;
+
+        clearSearchFlag
+            ? (setSearch(""), (searchRes = allData), (SearchBar.value = ""))
+            : (searchRes = allData.filter((item: Ileaderboard) =>
+                  item.userName.toLowerCase().includes(search.toLowerCase())
+              ));
         setSearchResult(searchRes);
     }
-    
+
     useEffect(() => {
         if (typeof window !== undefined) {
             window.addEventListener("scroll", () => {
@@ -71,7 +80,8 @@ const Leaderboard: React.FC = (leaderboardData) => {
                     🥇Clueless LeaderBoard🥇
                 </h1>
                 <p className="my-1.5 sm:my-3 text-center">
-                    Leaderboard will be updated everyday. Checkout the Points System{" "}
+                    Leaderboard will be updated everyday. Checkout the Points
+                    System{" "}
                     <a
                         href="https://clueless-resources.super.site/hacktoberfest/how-points-are-calculated"
                         target="_blank"
@@ -83,9 +93,46 @@ const Leaderboard: React.FC = (leaderboardData) => {
                     .
                 </p>
                 <div style={searchStyles}>
-                    <input  id="searchBar" style={{flex: 1, display:'flex', paddingLeft: 13, border: '1px solid black', borderRadius: 6, color: 'black'}} onChange={(e) => setSearch(e.target.value)}  type="text" placeholder="Enter your github username" />
-                    <button onClick={()=>{searchCards(true)}} style={{position:'relative', right:'60px',color:'blue'}}>Clear</button>
-                    <button onClick={()=>{searchCards(false)}} style={{background:'gray', width: 100, color:'white',borderRadius: 6, marginLeft:4}} >Search</button>
+                    <input
+                        id="searchBar"
+                        style={{
+                            flex: 1,
+                            display: "flex",
+                            paddingLeft: 13,
+                            border: "1px solid black",
+                            borderRadius: 6,
+                            color: "black",
+                        }}
+                        onChange={(e) => setSearch(e.target.value)}
+                        type="text"
+                        placeholder="Enter your github username"
+                    />
+                    <button
+                        onClick={() => {
+                            searchCards(true);
+                        }}
+                        style={{
+                            position: "relative",
+                            right: "60px",
+                            color: "blue",
+                        }}
+                    >
+                        Clear
+                    </button>
+                    <button
+                        onClick={() => {
+                            searchCards(false);
+                        }}
+                        style={{
+                            background: "gray",
+                            width: 100,
+                            color: "white",
+                            borderRadius: 6,
+                            marginLeft: 4,
+                        }}
+                    >
+                        Search
+                    </button>
                 </div>
                 <table className="w-full xl:text-xl text-lg box-content my-8 xl:my-12">
                     <thead className="bg-[#1C1525] text-white">
@@ -104,47 +151,76 @@ const Leaderboard: React.FC = (leaderboardData) => {
                         {/* {showButton && (<div id="return_top" style={{position:"fixed",zIndex:"99",right:"5%",top:"90%",width:"50px",height:"50px",textDecoration:"none",borderRadius:"50%",backgroundColor:"#0b5ac2",padding:"12px",display:"flex",alignItems:"center",justifyContent:"center"}}><button onClick={scrollToTop} className="fa fa-arrow-up" style={{color:"white",fontSize:"25px"}}></button></div>)} */}
 
                         {searchResult.map((data: Ileaderboard, i: number) => {
-              const avatarURL = data.avatarUrl === "#" ? "https://i.stack.imgur.com/YaL3s.jpg" : data.avatarUrl;
-              return (
-                data.userName != "Rajdip019" && (
-                  <tr className={`${i % 2 === 0 && "bg-[#DBE0EB] dark:bg-[#17202A]"} rounded-md`} key={i}>
-                    <td
-                      className={`my-2 pl-2 xl:rounded-tl-md rounded-tl-sm xl:rounded-bl-md rounded-bl-sm font-semibold`}
-                    >
-                      {data.position}.
-                    </td>
-                    <td className={`my-2 flex justify-start items-center xl:space-x-4 space-x-2 w-full`}>
-                        <img
-                            src={avatarURL}
-                            className="w-16 rounded-full border-dashed border-2 border-blue-400 text-sm "
-                            alt=""
-                            onClick={() => window.location.href=`https://github.com/${data.userName}`}
-                        />
-                        <span onClick={() => window.location.href=`https://github.com/${data.userName}`} className="max-w-[113px] truncate sm:max-w-fit">
-                            {data.userName}
-                        </span>
-                    </td>
-                    <td
-                      className={`my-2 pl-2 xl:rounded-tl-md rounded-tl-sm xl:rounded-bl-md rounded-bl-sm font-semibold text-center`}
+                            const avatarURL =
+                                data.avatarUrl === "#"
+                                    ? "https://i.stack.imgur.com/YaL3s.jpg"
+                                    : data.avatarUrl;
+                            return (
+                                data.userName != "Rajdip019" && (
+                                    <tr
+                                        className={`${
+                                            i % 2 === 0 &&
+                                            "bg-[#DBE0EB] dark:bg-[#17202A]"
+                                        } rounded-md`}
+                                        key={i}
                                     >
-                                        {data.PRCount}
-                                    </td>
-                                    <td className="my-2 pr-2 xl:rounded-tr-md rounded-tr-sm xl:rounded-br-md rounded-br-sm w-fit">
-                                        <div className="flex justify-start items-center space-x-2">
+                                        <td
+                                            className={`my-2 pl-2 xl:rounded-tl-md rounded-tl-sm xl:rounded-bl-md rounded-bl-sm font-semibold`}
+                                        >
+                                            {data.position}.
+                                        </td>
+                                        <td
+                                            className={`my-2 flex justify-start items-center xl:space-x-4 space-x-2 w-full`}
+                                        >
                                             <img
-                                                src="/leaderboardlogo.png"
-                                                alt="leaderboardLogo"
-                                                className="w-8"
+                                                src={avatarURL}
+                                                className="transition-all duration-75 hover:border-solid hover:brightness-75 w-16 rounded-full border-dashed border-2 border-blue-400 text-sm cursor-pointer"
+                                                alt=""
+                                                onClick={() =>
+                                                    window.open(
+                                                        `https://github.com/${data.userName}`,
+                                                        "_blank"
+                                                    )
+                                                }
                                             />
-                                            <span className="float-left">{data.Score}</span>
-                                        </div>
-                                    </td>
-                                </tr>
-                            ))
+                                            <span
+                                                onClick={() =>
+                                                    window.open(
+                                                        `https://github.com/${data.userName}`,
+                                                        "_blank"
+                                                    )
+                                                }
+                                                className="max-w-[113px] truncate sm:max-w-fit cursor-pointer hover:underline"
+                                            >
+                                                {data.userName}
+                                            </span>
+                                        </td>
+                                        <td
+                                            className={`my-2 pl-2 xl:rounded-tl-md rounded-tl-sm xl:rounded-bl-md rounded-bl-sm font-semibold text-center`}
+                                        >
+                                            {data.PRCount}
+                                        </td>
+                                        <td className="my-2 pr-2 xl:rounded-tr-md rounded-tr-sm xl:rounded-br-md rounded-br-sm w-fit">
+                                            <div className="flex justify-start items-center space-x-2">
+                                                <img
+                                                    src="/leaderboardlogo.png"
+                                                    alt="leaderboardLogo"
+                                                    className="w-8"
+                                                />
+                                                <span className="float-left">
+                                                    {data.Score}
+                                                </span>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                )
+                            );
                         })}
                     </tbody>
                 </table>
-                {searchResult.length == 0 && <p className="text-center" >No results found</p>}
+                {searchResult.length == 0 && (
+                    <p className="text-center">No results found</p>
+                )}
                 {showButton && (
                     <FaAngleUp
                         style={{
@@ -161,7 +237,7 @@ const Leaderboard: React.FC = (leaderboardData) => {
                             display: "flex",
                             alignItems: "center",
                             justifyContent: "center",
-                            color: 'white'
+                            color: "white",
                         }}
                         className="icon-position icon-style hover:cursor-pointer hover:-translate-y-2 hover:ease-in-out transition"
                         onClick={scrollToTop}


### PR DESCRIPTION
## Description
<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Added hover effects to images and names in the leaderboard and after clicking those the GitHub profiles open in new tab
---
## Issue Ticket Number
Fixes #418 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation