### PR TITLE
Fixed the position of the theme select button

### DIFF
--- a/pages/components/shared/Navbar/ModeSelect.tsx
+++ b/pages/components/shared/Navbar/ModeSelect.tsx
@@ -69,7 +69,7 @@ const ModeSelect = () => {
   }
   console.log("current theme", theme);
   return (
-    <div>
+    <div className="flex flex-row items-center justify-center lg:mr-20">
       <IconButton
         id="basic-button"
         aria-controls={open ? "basic-menu" : undefined}


### PR DESCRIPTION
## Description
I have fixed the position of the theme select button which was placed very close to the Login button.

## Before 👇

![Screenshot 2022-10-27 220134](https://user-images.githubusercontent.com/85431456/198348343-3230bc76-e299-4ea3-b47f-b48f45da042e.png)


## After 👇

![Screenshot 2022-10-27 220121](https://user-images.githubusercontent.com/85431456/198348404-10ea092e-d4e8-48dc-9d08-624b40fe4f65.png)

---
## Type of change
<!-- Please select all options that are applicable. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation