### PR TITLE
Made icons from Dive into the world of Development section clickable

### DIFF
--- a/pages/components/shared/TeachStackLine.tsx
+++ b/pages/components/shared/TeachStackLine.tsx
@@ -1,19 +1,27 @@
 /* eslint-disable @next/next/no-img-element */
 import React from "react";
 
-const Icons = [...Array(8)].map((_, i) => `/icons/icon${i + 1}.svg`);
+const icons = [{name: "/icons/icon1.svg", url: "https://flutter.dev/"},
+                {name: "/icons/icon2.svg", url: "https://kubernetes.io/"},
+                {name: "/icons/icon3.svg", url: "https://redux.js.org/"},
+                {name: "/icons/icon4.svg", url: "https://ethereum.org/en/"},
+                {name: "/icons/icon5.svg", url: "https://reactjs.org/"},
+                {name: "/icons/icon6.svg", url: "https://code.visualstudio.com/"},
+                {name: "/icons/icon7.svg", url: "https://www.linux.org/"},
+                {name: "/icons/icon8.svg", url: "https://d3js.org/"}
+              ]
 
 const TeachStackLine = () => {
   return (
     <div className="relative md:mx-40 mx-auto">
       <div className="hidden lg:block">
-        <div className="grid grid-cols-10 place-items-center gap-4 px-12 py-8">
-          {Icons.slice(0, 4).map((icon, i) => {
-            return <img src={icon} alt={icon} key={i} />;
+        <div className="flex flex-row items-center justify-center gap-[18px] py-8">
+          {icons.slice(0, 4).map((icon, i) => {
+            return <a href={icon.url} key={i} target="blank"><img src={icon.name} alt={icon.url} key={i} /></a>;
           })}
-          <img src="/icons/iconmiddle.svg" alt="github" className="col-span-2 dark:invert dark:brightness-0" />
-          {Icons.slice(4, 8).map((icon, i) => {
-            return <img src={icon} alt={icon} key={i} />;
+          <a href="https://github.com/" target="blank" className="w-[200px] h-[150px] flex flex-row justify-center items-center"><img src="/icons/iconmiddle.svg" alt="github" className="w-[150px] col-span-2 dark:invert dark:brightness-0" /></a>
+          {icons.slice(4, 8).map((icon, i) => {
+            return <a href={icon.url} key={i} target="blank"><img src={icon.name} alt={icon.url} key={i} /></a>;
           })}
         </div>
       </div>

--- a/public/icons/icon1.svg
+++ b/public/icons/icon1.svg
@@ -1,18 +1,1 @@
-<svg width="256" height="317" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" version="1.1">
- <defs>
-  <linearGradient y2="0.58693" x2="0.73801" y1="0.32763" x1="0.01853" id="SVGID_1_">
-   <stop stop-color="#000000" offset="0"/>
-   <stop stop-opacity="0" stop-color="#000000" offset="1"/>
-  </linearGradient>
- </defs>
- <g>
-  <title>Layer 1</title>
-  <g stroke="null" id="svg_1">
-   <polygon stroke="null" id="svg_2" fill="#47C5FB" points="155.9040069580078,15.999990463256836 13,156.97454833984375 57.229820251464844,200.6072235107422 244.3636474609375,15.999990463256836 " class="st0"/>
-   <polygon stroke="null" id="svg_3" fill="#47C5FB" points="155.81336975097656,146.26699829101562 79.29940032958984,221.38412475585938 123.69235229492188,265.61614990234375 167.84060668945312,222.27389526367188 245.26998901367188,146.26699829101562 " class="st0"/>
-   <polygon stroke="null" id="svg_4" fill="#00569E" points="123.69235229492188,265.61614990234375 157.29978942871094,298.6099853515625 245.26998901367188,298.6099853515625 167.84060668945312,222.27389526367188 " class="st2"/>
-   <polygon stroke="null" id="svg_5" fill="#00B5F8" points="78.80091857910156,221.86459350585938 123.03074645996094,178.44223022460938 167.84060668945312,222.27389526367188 123.69235229492188,265.61614990234375 " class="st3"/>
-   <polygon stroke="null" id="svg_6" fill-opacity="0.8" fill="url(#SVGID_1_)" points="123.69235229492188,265.61614990234375 160.45387268066406,253.63943481445312 164.1064453125,225.93988037109375 " class="st1"/>
-  </g>
- </g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 48 48" width="120px" height="120px"><polygon fill="#40c4ff" points="26,4 6,24 12,30 38,4"/><polygon fill="#40c4ff" points="38,22 27,33 21,27 26,22"/><rect width="8.485" height="8.485" x="16.757" y="28.757" fill="#03a9f4" transform="rotate(-45.001 21 33)"/><polygon fill="#01579b" points="38,44 26,44 21,39 27,33"/><polygon fill="#084994" points="21,39 30,36 27,33"/></svg>


### PR DESCRIPTION
## Description
I have made icons from the 'Dive into the world of Development' section clickable by adding hyperlinks to them to their respective websites.

👇

https://user-images.githubusercontent.com/85431456/198599402-9f33efb2-2b4a-4430-a50a-499fd6586570.mp4


---
## Issue Ticket Number
Fixes #385 

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation