### PR TITLE
Fixed the icons position in What is Clueless section

### DIFF
--- a/pages/components/Home/WhatIsClueLess.tsx
+++ b/pages/components/Home/WhatIsClueLess.tsx
@@ -32,7 +32,7 @@ const WhatIsClueLess: React.FC = () => {
           }}
         />
         <StorageIcon
-          className="absolute text-5xl hover:scale-125 transition-all cursor-pointer hover:text-skin-main text-skin-hoverBlue  md:block top-12 2xl:left-60 xl:left-28 left-10 sm:left-24"
+          className="absolute text-5xl hover:scale-125 transition-all cursor-pointer hover:text-skin-main text-skin-hoverBlue  md:block top-12 2xl:left-40 xl:left-28 left-10 sm:left-24"
           fontSize='inherit' sx={{ fontSize: "50px" }}
           onMouseOver={() => {
             setState(2);
@@ -42,7 +42,7 @@ const WhatIsClueLess: React.FC = () => {
           }}
         />
         <LocalPoliceIcon
-          className="absolute text-5xl hover:scale-125 transition-all cursor-pointer hover:text-skin-main text-skin-hoverBlue  md:block top-12 2xl:right-72 xl:right-40 sm:right-24 right-10"
+          className="absolute text-5xl hover:scale-125 transition-all cursor-pointer hover:text-skin-main text-skin-hoverBlue  md:block top-12 2xl:right-52 xl:right-40 sm:right-24 right-10"
           fontSize='inherit' sx={{ fontSize: "50px" }}
           onMouseOver={() => {
             setState(3);


### PR DESCRIPTION
## Description
I have fixed the positions of icons in the 'What is Clueless' section for desktop view.


## Before 👇

![Screenshot 2022-10-30 003107](https://user-images.githubusercontent.com/85431456/198848756-38499462-a382-487c-8929-4d79a3a8c239.png)


## After 👇

![Screenshot 2022-10-30 003825](https://user-images.githubusercontent.com/85431456/198848763-e87be3cc-b65d-4939-b1d1-62dc070e1636.png)


---
## Type of change
<!-- Please select all options that are applicable. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation