### PR TITLE
Fixed rounded borders on left side of the PR Merged column in leaderboard

### DIFF
--- a/pages/components/Home/WhatIsClueLess.tsx
+++ b/pages/components/Home/WhatIsClueLess.tsx
@@ -32,7 +32,7 @@ const WhatIsClueLess: React.FC = () => {
           }}
         />
         <StorageIcon
-          className="absolute text-5xl hover:scale-125 transition-all cursor-pointer hover:text-skin-main text-skin-hoverBlue  md:block top-12 2xl:left-60 xl:left-28 left-10 sm:left-24"
+          className="absolute text-5xl hover:scale-125 transition-all cursor-pointer hover:text-skin-main text-skin-hoverBlue  md:block top-12 2xl:left-40 xl:left-28 left-10 sm:left-24"
           fontSize='inherit' sx={{ fontSize: "50px" }}
           onMouseOver={() => {
             setState(2);
@@ -42,7 +42,7 @@ const WhatIsClueLess: React.FC = () => {
           }}
         />
         <LocalPoliceIcon
-          className="absolute text-5xl hover:scale-125 transition-all cursor-pointer hover:text-skin-main text-skin-hoverBlue  md:block top-12 2xl:right-72 xl:right-40 sm:right-24 right-10"
+          className="absolute text-5xl hover:scale-125 transition-all cursor-pointer hover:text-skin-main text-skin-hoverBlue  md:block top-12 2xl:right-52 xl:right-40 sm:right-24 right-10"
           fontSize='inherit' sx={{ fontSize: "50px" }}
           onMouseOver={() => {
             setState(3);

--- a/pages/hacktoberfest/leaderboard.tsx
+++ b/pages/hacktoberfest/leaderboard.tsx
@@ -192,7 +192,7 @@ const Leaderboard: React.FC = (leaderboardData) => {
                                             </span>
                                         </td>
                                         <td
-                                            className={`my-2 pl-2 xl:rounded-tl-md rounded-tl-sm xl:rounded-bl-md rounded-bl-sm font-semibold text-center`}
+                                            className={`my-2 pl-2 font-semibold text-center`}
                                         >
                                             {data.PRCount}
                                         </td>


### PR DESCRIPTION
## Description
I have fixed a small UI glitch in the leaderboard. The left side of the 'PR Merged' column had rounded borders in the desktop view which wasn't looking good. So, removed that.


## Before 👇

![Screenshot 2022-10-27 231950](https://user-images.githubusercontent.com/85431456/198849212-b374698c-d6bb-4096-8461-e64f541005bc.png)


## After 👇

![Screenshot 2022-10-27 232037](https://user-images.githubusercontent.com/85431456/198849229-e4421e14-6bd7-4e9b-8b98-34b27f3cc40c.png)


---
## Type of change
<!-- Please select all options that are applicable. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/Clueless-Community/clueless-official-website/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation