### PR TITLE
fixed space between testimonial cards

### DIFF
--- a/components/home/Testimonials/testimonialsMobile.tsx
+++ b/components/home/Testimonials/testimonialsMobile.tsx
@@ -12,6 +12,7 @@ const MobileSwipper = () => {
     centerMode: true,
     autoplaySpeed: 2000,
     cssEase: 'linear',
+    variableWidth: true,
   };
   return (
     <div className="">

--- a/components/home/Testimonials/testimonialsMobile.tsx
+++ b/components/home/Testimonials/testimonialsMobile.tsx
@@ -13,6 +13,7 @@ const MobileSwipper = () => {
     autoplaySpeed: 2000,
     cssEase: 'linear',
     variableWidth: true,
+    adaptiveHeight: true,
   };
   return (
     <div className="">


### PR DESCRIPTION
# for issue #573 

* added ```variableWidth: true``` in settings of slick to adjust space between two cards in testimonial section
* attached screenshots of different screen Size

<img width="596" alt="Screenshot 2023-04-09 171650" src="https://user-images.githubusercontent.com/102145959/230771056-a46708a2-5297-49be-bb05-017bfe661afb.png">

<img width="449" alt="Screenshot 2023-04-09 171804" src="https://user-images.githubusercontent.com/102145959/230771059-de0d9f2b-0fd6-4529-a2a5-6f92f7a43b41.png">
<img width="665" alt="Screenshot 2023-04-09 171835" src="https://user-images.githubusercontent.com/102145959/230771063-e02dabfb-67ec-40b5-a267-24ac45d42425.png">
