### PR TITLE
feat: Update Footer to Display Dynamic Year

### DIFF
--- a/components/shared/Footer.tsx
+++ b/components/shared/Footer.tsx
@@ -7,6 +7,7 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import Link from 'next/link';
 
 const Footer: React.FC = () => {
+  const currentYear = new Date().getFullYear();
   const ClueLogo = (color: string) => {
     return (
       <div style={{ margin: '2px' }}>
@@ -127,7 +128,7 @@ const Footer: React.FC = () => {
         </div>
       </div>
       <div className="sm:px-40 flex justify-between text-sm py-10 bg-[#1B1B1B] text-white flex-col items-center sm:flex-row shadow-xl dark:bg-zinc-900">
-        <p>Copyright &copy; by ClueLess 2023</p>
+        <p>&copy; {currentYear} by ClueLess</p>
         <p className="mt-5 sm:mt-0">Powered by Clueless</p>
       </div>
     </>


### PR DESCRIPTION
This PR solves issue number #606 

This pull request aims to update the Footer component to display the dynamic current year instead of the hardcoded "2023".

## Proposed Changes:

1. Introduce JavaScript code to retrieve the current year dynamically.
2. Replace the static year in the footer with the dynamically obtained current year.

By making this change, the Footer component will always display the correct and up-to-date year without requiring manual updates.

Please review the changes and merge them into the main branch to ensure the Footer reflects the current year dynamically.

![Screenshot 2023-06-02 022822](https://github.com/Clueless-Community/clueless-official-website/assets/96189881/de05f95e-1776-47b2-8de7-d1bba1ac2c1e)